### PR TITLE
🔀 :: (#422) AsyncConfigurer를 override하여 asyncExecutor 설정

### DIFF
--- a/src/main/java/com/walkhub/walkhub/global/async/AsyncConfig.java
+++ b/src/main/java/com/walkhub/walkhub/global/async/AsyncConfig.java
@@ -1,8 +1,27 @@
 package com.walkhub.walkhub.global.async;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @EnableAsync
 @Configuration
-public class AsyncConfig { }
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("async-thread-");
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(100);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.initialize();
+
+        return executor;
+    }
+}


### PR DESCRIPTION
Closes #422

오랜만입니다.
`AsyncExecutor` 기본 `thread pool` 설정해왔습니다.

기본 동작 쓰레드 10개,
최대치 50개,
최대치 초과 시 `Queue`에 100개까지 담기도록 하였습니다.